### PR TITLE
Add turn-based gameplay with custom dice and player colors

### DIFF
--- a/556/marrakesh/client/lib/api.ts
+++ b/556/marrakesh/client/lib/api.ts
@@ -32,6 +32,24 @@ function getUserByToken(token?: string | null): User | null {
   if (!token) return null; const tokens = getTokens(); const userId = tokens[token]; if (!userId) return null; const users = getUsers(); const u = users.find((x) => x.id === userId); if (!u) return null; const { password: _pw, ...user } = u; return user;
 }
 
+function activePlayerIdFor(session: Session, st: GameState): string | undefined {
+  return st.activePlayerId ?? session.activePlayerId ?? session.turnOrder[0];
+}
+
+function ensureUser(token?: string | null): User {
+  const me = getUserByToken(token);
+  if (!me) throw new Error("Требуется вход в систему");
+  return me;
+}
+
+function ensureActiveTurn(session: Session, st: GameState, token?: string | null): User {
+  const me = ensureUser(token);
+  const activeId = activePlayerIdFor(session, st);
+  if (!activeId) throw new Error("Нет активного игрока");
+  if (me.id !== activeId) throw new Error("Сейчас ход противника");
+  return me;
+}
+
 function emptyGrid(n: number): RugCell[][] { return Array.from({ length: n }, () => Array.from({ length: n }, () => ({ stack: [] })) ); }
 
 function ensureGameState(session: Session): GameState {
@@ -178,7 +196,7 @@ export const API = {
   // Sessions
   async listSessions(_token?: string): Promise<Session[]> { return getSessions().slice().sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)); },
   async createSession(payload: CreateSessionPayload, token?: string): Promise<Session> {
-    const me = getUserByToken(token); if (!me) throw new Error("Требуется вход в систему"); const sessions = getSessions(); const id = generateId(); const status: SessionStatus = "waiting";
+    const me = getUserByToken(token); if (!me) throw new Error("Требуется вход �� систему"); const sessions = getSessions(); const id = generateId(); const status: SessionStatus = "waiting";
     const session: Session = { id, name: payload.name || "Новая партия", players: [me], status, turnOrder: [me.id], activePlayerId: me.id, createdAt: nowIso() };
     sessions.unshift(session); setSessions(sessions); return session;
   },
@@ -229,7 +247,7 @@ export const API = {
   },
   async deleteSession(sessionId: string, token?: string) {
     const me = getUserByToken(token);
-    if (!me) throw new Error("Требуется вход в систему");
+    if (!me) throw new Error("Требуется ��ход в систему");
     const sessions = getSessions();
     const existing = sessions.find((session) => session.id === sessionId);
     if (!existing) throw new Error("Сессия не найдена");
@@ -246,8 +264,13 @@ export const API = {
   async getGameState(sessionId: string, _token?: string) { const s = requireSession(sessionId); const st = ensureGameState(s); return st; },
 
   // Actions
-  async rotate(sessionId: string, turn: "left" | "right", _token?: string) {
-    const session = requireSession(sessionId); const states = getStates(); const st = ensureGameState(session); const dir = rotate(st.direction || "N", turn); const updated: GameState = { ...st, direction: dir }; states[sessionId] = updated; setStates(states); return updated;
+  async rotate(sessionId: string, turn: "left" | "right", token?: string) {
+    const session = requireSession(sessionId); const states = getStates(); const st = ensureGameState(session);
+    if (st.status === "finished") throw new Error("Игра завершена");
+    ensureActiveTurn(session, st, token);
+    const dir = rotate(st.direction || "N", turn); const updated: GameState = { ...st, direction: dir };
+    states[sessionId] = updated; setStates(states);
+    return updated;
   },
   async step(sessionId: string, _token?: string) {
     const session = requireSession(sessionId); const states = getStates(); let st = ensureGameState(session); const nxt = stepForward(st); st = { ...st, pieces: [{ id: "assam", x: nxt.x, y: nxt.y }], direction: nxt.dir };
@@ -255,17 +278,26 @@ export const API = {
     st = applyPayment(st, st.activePlayerId || session.activePlayerId || session.turnOrder[0], nxt.x, nxt.y);
     states[sessionId] = st; setStates(states); return st;
   },
-  async rollDice(sessionId: string, _token?: string) {
-    const session = requireSession(sessionId); const states = getStates(); let st = ensureGameState(session); const roll = 1 + Math.floor(Math.random() * 6); let res = st; for (let i = 0; i < roll; i++) { res = await this.step(sessionId, _token); st = res; }
+  async rollDice(sessionId: string, token?: string) {
+    const session = requireSession(sessionId); const states = getStates(); let st = ensureGameState(session);
+    if (st.status === "finished") throw new Error("Игра завершена");
+    ensureActiveTurn(session, st, token);
+    const diceFaces = [1, 2, 2, 3, 3, 4];
+    const roll = diceFaces[Math.floor(Math.random() * diceFaces.length)];
+    let res = st;
+    for (let i = 0; i < roll; i++) { res = await this.step(sessionId, token); st = res; }
     const updated: GameState = { ...st, lastRoll: roll };
     states[sessionId] = updated; setStates(states);
-    saveSession({ ...session, activePlayerId: updated.activePlayerId });
+    saveSession({ ...session, activePlayerId: activePlayerIdFor(session, updated) });
     return updated;
   },
   async placeRug(sessionId: string, body: { x: number; y: number; orientation: "H" | "V" }, token?: string) {
-    const me = getUserByToken(token); if (!me) throw new Error("Требуется вход в систему"); const session = requireSession(sessionId); const states = getStates(); const st0 = ensureGameState(session);
+    const session = requireSession(sessionId); const states = getStates(); const st0 = ensureGameState(session);
+    if (st0.status === "finished") throw new Error("Игра завершена");
+    const me = ensureActiveTurn(session, st0, token);
     const stPlaced = placeRug(st0, me.id, body.x, body.y, body.orientation);
-    const nextActive = nextPlayerId(session, stPlaced.activePlayerId);
+    const currentActive = activePlayerIdFor(session, stPlaced) ?? me.id;
+    const nextActive = nextPlayerId(session, currentActive);
     const st1: GameState = { ...stPlaced, activePlayerId: nextActive };
     states[sessionId] = st1; setStates(states);
     saveSession({ ...session, activePlayerId: nextActive });

--- a/556/marrakesh/client/lib/api.ts
+++ b/556/marrakesh/client/lib/api.ts
@@ -46,7 +46,7 @@ function ensureActiveTurn(session: Session, st: GameState, token?: string | null
   const me = ensureUser(token);
   const activeId = activePlayerIdFor(session, st);
   if (!activeId) throw new Error("Нет активного игрока");
-  if (me.id !== activeId) throw new Error("С��йчас ход противника");
+  if (me.id !== activeId) throw new Error("Сейчас ход противника");
   return me;
 }
 
@@ -158,8 +158,8 @@ function canPlaceRug(st: GameState, playerId: string, x: number, y: number, orie
   const cells: [number, number][] = orient === "H" ? [[x, y], [x + 1, y]] : [[x, y], [x, y + 1]];
   for (const [cx, cy] of cells) { if (cx < 0 || cy < 0 || cx >= n || cy >= n) return { ok: false, reason: "Вне поля" }; if (cx === assam.x && cy === assam.y) return { ok: false, reason: "Нельзя на клетку Ассама" }; }
   if (!cells.some(([cx, cy]) => (Math.abs(cx - assam.x) + Math.abs(cy - assam.y)) === 1)) return { ok: false, reason: "Должен соприкасаться с Ассамом" };
-  const top0 = grid[cells[0][1]][cells[0][0]].stack.at(-1);
-  const top1 = grid[cells[1][1]][cells[1][0]].stack.at(-1);
+  const top0 = topLayer(grid[cells[0][1]][cells[0][0]].stack);
+  const top1 = topLayer(grid[cells[1][1]][cells[1][0]].stack);
   if ((top0?.ownerId === playerId) || (top1?.ownerId === playerId)) return { ok: false, reason: "Нельзя накрывать свой ковёр" };
   if (top0 && top1 && top0.rugId === top1.rugId) return { ok: false, reason: "Нельзя полностью накрыть ковёр" };
   return { ok: true };
@@ -178,7 +178,7 @@ function placeRug(st: GameState, playerId: string, x: number, y: number, orient:
     // finish game: coins + visible tiles
     const balances = { ...(st.balances || {}) };
     const visibleCount: Record<string, number> = {};
-    for (let yy = 0; yy < grid.length; yy++) for (let xx = 0; xx < grid.length; xx++) { const top = grid[yy][xx].stack.at(-1); if (top) visibleCount[top.ownerId] = (visibleCount[top.ownerId] ?? 0) + 1; }
+    for (let yy = 0; yy < grid.length; yy++) for (let xx = 0; xx < grid.length; xx++) { const top = topLayer(grid[yy][xx].stack); if (top) visibleCount[top.ownerId] = (visibleCount[top.ownerId] ?? 0) + 1; }
     let winnerId = Object.keys(balances)[0]; let best = -Infinity;
     for (const pid of Object.keys(balances)) { const score = (balances[pid] ?? 0) + (visibleCount[pid] ?? 0); if (score > best) { best = score; winnerId = pid; } }
     return { ...st, rugsGrid: grid, rugsLeft, status: "finished", winnerId };

--- a/556/marrakesh/client/lib/api.ts
+++ b/556/marrakesh/client/lib/api.ts
@@ -46,11 +46,15 @@ function ensureActiveTurn(session: Session, st: GameState, token?: string | null
   const me = ensureUser(token);
   const activeId = activePlayerIdFor(session, st);
   if (!activeId) throw new Error("Нет активного игрока");
-  if (me.id !== activeId) throw new Error("Сейчас ход противника");
+  if (me.id !== activeId) throw new Error("С��йчас ход противника");
   return me;
 }
 
 function emptyGrid(n: number): RugCell[][] { return Array.from({ length: n }, () => Array.from({ length: n }, () => ({ stack: [] })) ); }
+
+function topLayer(stack?: RugLayer[]): RugLayer | undefined {
+  return stack && stack.length ? stack[stack.length - 1] : undefined;
+}
 
 function ensureGameState(session: Session): GameState {
   const all = getStates(); const cur = all[session.id];
@@ -196,7 +200,7 @@ export const API = {
   // Sessions
   async listSessions(_token?: string): Promise<Session[]> { return getSessions().slice().sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)); },
   async createSession(payload: CreateSessionPayload, token?: string): Promise<Session> {
-    const me = getUserByToken(token); if (!me) throw new Error("Требуется вход �� систему"); const sessions = getSessions(); const id = generateId(); const status: SessionStatus = "waiting";
+    const me = getUserByToken(token); if (!me) throw new Error("Требуется вход в систему"); const sessions = getSessions(); const id = generateId(); const status: SessionStatus = "waiting";
     const session: Session = { id, name: payload.name || "Новая партия", players: [me], status, turnOrder: [me.id], activePlayerId: me.id, createdAt: nowIso() };
     sessions.unshift(session); setSessions(sessions); return session;
   },
@@ -247,7 +251,7 @@ export const API = {
   },
   async deleteSession(sessionId: string, token?: string) {
     const me = getUserByToken(token);
-    if (!me) throw new Error("Требуется ��ход в систему");
+    if (!me) throw new Error("Требуется вход в систему");
     const sessions = getSessions();
     const existing = sessions.find((session) => session.id === sessionId);
     if (!existing) throw new Error("Сессия не найдена");

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -143,7 +143,7 @@ export default function SessionPage() {
         };
       }),
     );
-  }, [state, size]);
+  }, [playerColors, state, size]);
 
   async function onRotate(turn: "left" | "right") {
     try { const st = await API.rotate(id, turn, token ?? undefined); setState(st); } catch (e: any) { toast.error(e.message || "��шибка поворота"); }

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -52,7 +52,7 @@ export default function SessionPage() {
   const isMyTurn = Boolean(user && activePlayerId === user.id);
   const gameFinished = state?.status === "finished";
   const opponentTurnMessage = "Сейчас ход противника";
-  const placementPendingMessage = "Сначала завершите размещение ковра";
+  const placementPendingMessage = "Сначала завершите размещен��е ковра";
   const loginToPlayMessage = "Войдите, чтобы играть";
   const activePlayerName = players.find((p) => p.id === activePlayerId)?.name;
   const turnMessage = gameFinished
@@ -104,6 +104,10 @@ export default function SessionPage() {
 
   function colorFor(id: string) {
     return playerColors[id] ?? baseColorFor(id);
+  }
+
+  function topStack<T>(stack?: T[]): T | undefined {
+    return stack && stack.length ? stack[stack.length - 1] : undefined;
   }
 
   const rugsTop = useMemo(() => {

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -216,8 +216,6 @@ export default function SessionPage() {
     }
   }
 
-  const players = session?.players ?? [];
-
   return (
     <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1fr_320px] bg-white p-2 sm:p-4 rounded-md">
       <section className="space-y-4">

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -247,13 +247,16 @@ export default function SessionPage() {
         </div>
 
         <div className="rounded-xl border p-0 overflow-hidden">
-          <div className="border-b bg-muted/50 px-4 py-2 text-sm font-medium">И��роки</div>
+          <div className="border-b bg-muted/50 px-4 py-2 text-sm font-medium">Игроки</div>
           <ul className="divide-y">
             {players.map((p) => (
               <li key={p.id} className="flex items-center justify-between gap-3 px-4 py-2 text-sm">
                 <div className="flex items-center gap-2">
                   <span className="flex size-6 items-center justify-center rounded-full" style={{ backgroundColor: colorFor(p.id) }}>{p.name?.[0]?.toUpperCase() || "?"}</span>
-                  <span className={p.id === state?.activePlayerId ? "font-semibold text-foreground" : "text-foreground"}>{p.name}</span>
+                  <div className="flex flex-col leading-tight">
+                    <span className={p.id === activePlayerId ? "font-semibold text-foreground" : "text-foreground"}>{p.name}</span>
+                    <span className={p.id === activePlayerId ? "text-xs font-medium text-emerald-600" : p.id === user?.id ? "text-xs font-medium text-amber-600" : "text-xs text-muted-foreground"}>{playerStatusText(p.id)}</span>
+                  </div>
                 </div>
                 <div className="flex items-center gap-3 text-muted-foreground">
                   <span title="Монеты" className="min-w-10 text-right">💰 {state?.balances?.[p.id] ?? 30}</span>

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -47,6 +47,39 @@ export default function SessionPage() {
     return () => stopPoll();
   }, [id, token]);
 
+  const players = session?.players ?? [];
+  const activePlayerId = state?.activePlayerId;
+  const isMyTurn = Boolean(user && activePlayerId === user.id);
+  const gameFinished = state?.status === "finished";
+  const opponentTurnMessage = "Сейчас ход противника";
+  const placementPendingMessage = "Сначала завершите размещение ковра";
+  const activePlayerName = players.find((p) => p.id === activePlayerId)?.name;
+  const turnMessage = gameFinished
+    ? "Игра завершена"
+    : user
+      ? isMyTurn
+        ? "Ваш ход"
+        : opponentTurnMessage
+      : activePlayerName
+        ? `Ходит ${activePlayerName}`
+        : "Ожидание игроков";
+  const canInteract = isMyTurn && !gameFinished;
+
+  function playerStatusText(playerId: string) {
+    const isActive = playerId === activePlayerId;
+    if (user && playerId === user.id) {
+      return isActive ? "Ваш ход" : opponentTurnMessage;
+    }
+    return isActive ? "Сейчас ходит" : "Ожидает";
+  }
+
+  useEffect(() => {
+    if (!isMyTurn || gameFinished) {
+      setPlacingPhase(0);
+      setFirstCell(null);
+    }
+  }, [isMyTurn, gameFinished]);
+
   const tokenViews: Token[] = useMemo(() => {
     const p = state?.pieces?.[0];
     if (!p) return [];

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -52,7 +52,7 @@ export default function SessionPage() {
   const isMyTurn = Boolean(user && activePlayerId === user.id);
   const gameFinished = state?.status === "finished";
   const opponentTurnMessage = "Сейчас ход противника";
-  const placementPendingMessage = "Сначала завершите размещен��е ковра";
+  const placementPendingMessage = "Сначала завершите размещение ковра";
   const loginToPlayMessage = "Войдите, чтобы играть";
   const activePlayerName = players.find((p) => p.id === activePlayerId)?.name;
   const turnMessage = gameFinished
@@ -114,13 +114,13 @@ export default function SessionPage() {
     const n = size; const grid = state?.rugsGrid; if (!grid) return [] as any;
     return grid.map((row, y) =>
       row.map((cell, x) => {
-        const top = cell.stack.at(-1);
+        const top = topStack(cell.stack);
         if (!top) return undefined;
         const { ownerId, rugId } = top;
-        const right = grid[y]?.[x + 1]?.stack.at(-1);
-        const left = grid[y]?.[x - 1]?.stack.at(-1);
-        const down = grid[y + 1]?.[x]?.stack.at(-1);
-        const up = grid[y - 1]?.[x]?.stack.at(-1);
+        const right = topStack(grid[y]?.[x + 1]?.stack);
+        const left = topStack(grid[y]?.[x - 1]?.stack);
+        const down = topStack(grid[y + 1]?.[x]?.stack);
+        const up = topStack(grid[y - 1]?.[x]?.stack);
 
         let orientation: "H" | "V" | undefined;
         let segment: "start" | "end" | undefined;

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -88,9 +88,21 @@ export default function SessionPage() {
 
   const size = state?.boardSize || 7;
 
-  function colorFor(id: string) {
+  function baseColorFor(id: string) {
     let hash = 0; for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
     const hue = hash % 360; return `hsl(${hue} 70% 60%)`;
+  }
+
+  const playerColors = useMemo(() => {
+    const colorMap: Record<string, string> = {};
+    players.forEach((player, index) => {
+      colorMap[player.id] = index === 1 ? "#dc2626" : baseColorFor(player.id);
+    });
+    return colorMap;
+  }, [players]);
+
+  function colorFor(id: string) {
+    return playerColors[id] ?? baseColorFor(id);
   }
 
   const rugsTop = useMemo(() => {

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -186,7 +186,6 @@ export default function SessionPage() {
       return;
     }
     if (!state?.pieces?.[0] || gameFinished) return;
-    if (!state?.pieces?.[0]) return;
     const a = state.pieces[0];
     if (placingPhase === 0) return;
     if (placingPhase === 1) {

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -147,13 +147,45 @@ export default function SessionPage() {
   }, [playerColors, state, size]);
 
   async function onRotate(turn: "left" | "right") {
-    try { const st = await API.rotate(id, turn, token ?? undefined); setState(st); } catch (e: any) { toast.error(e.message || "��шибка поворота"); }
+    if (gameFinished) return;
+    if (!user) {
+      toast.info(loginToPlayMessage);
+      return;
+    }
+    if (!canInteract) {
+      toast.info(opponentTurnMessage);
+      return;
+    }
+    if (placingPhase !== 0) return;
+    try { const st = await API.rotate(id, turn, token ?? undefined); setState(st); } catch (e: any) { toast.error(e.message || "Ошибка поворота"); }
   }
   async function onRoll() {
+    if (gameFinished) return;
+    if (!user) {
+      toast.info(loginToPlayMessage);
+      return;
+    }
+    if (!canInteract) {
+      toast.info(opponentTurnMessage);
+      return;
+    }
+    if (placingPhase !== 0) {
+      toast.info(placementPendingMessage);
+      return;
+    }
     try { const st = await API.rollDice(id, token ?? undefined); setState(st); setPlacingPhase(1); setFirstCell(null); } catch (e: any) { toast.error(e.message || "Ошибка броска"); }
   }
 
   async function onCellClick(x: number, y: number) {
+    if (!user) {
+      toast.info(loginToPlayMessage);
+      return;
+    }
+    if (!canInteract) {
+      toast.info(opponentTurnMessage);
+      return;
+    }
+    if (!state?.pieces?.[0] || gameFinished) return;
     if (!state?.pieces?.[0]) return;
     const a = state.pieces[0];
     if (placingPhase === 0) return;
@@ -197,7 +229,7 @@ export default function SessionPage() {
             <div className="text-sm font-semibold">Кубик: {state?.lastRoll ?? "—"}</div>
             <Button onClick={onRoll} className="w-full">Бросить</Button>
             <div className="text-xs text-muted-foreground">
-              {placingPhase === 0 && "��начала выберите направление и бросьте кубик"}
+              {placingPhase === 0 && "Сначала выберите направление и бросьте кубик"}
               {placingPhase === 1 && "Выберите первую клетку рядом с Ассамом"}
               {placingPhase === 2 && "Выберите вторую клетку, соседнюю с первой (не клетка Ассама)"}
             </div>

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -53,6 +53,7 @@ export default function SessionPage() {
   const gameFinished = state?.status === "finished";
   const opponentTurnMessage = "Сейчас ход противника";
   const placementPendingMessage = "Сначала завершите размещение ковра";
+  const loginToPlayMessage = "Войдите, чтобы играть";
   const activePlayerName = players.find((p) => p.id === activePlayerId)?.name;
   const turnMessage = gameFinished
     ? "Игра завершена"
@@ -62,7 +63,7 @@ export default function SessionPage() {
         : opponentTurnMessage
       : activePlayerName
         ? `Ходит ${activePlayerName}`
-        : "Ожидание игроков";
+        : loginToPlayMessage;
   const canInteract = isMyTurn && !gameFinished;
 
   function playerStatusText(playerId: string) {
@@ -196,7 +197,7 @@ export default function SessionPage() {
             <div className="text-sm font-semibold">Кубик: {state?.lastRoll ?? "—"}</div>
             <Button onClick={onRoll} className="w-full">Бросить</Button>
             <div className="text-xs text-muted-foreground">
-              {placingPhase === 0 && "Сначала выберите направление и бросьте кубик"}
+              {placingPhase === 0 && "��начала выберите направление и бросьте кубик"}
               {placingPhase === 1 && "Выберите первую клетку рядом с Ассамом"}
               {placingPhase === 2 && "Выберите вторую клетку, соседнюю с первой (не клетка Ассама)"}
             </div>

--- a/556/marrakesh/client/pages/Session.tsx
+++ b/556/marrakesh/client/pages/Session.tsx
@@ -225,9 +225,12 @@ export default function SessionPage() {
           <div className="rounded-2xl border bg-card p-4">
             <Board size={size} tokens={tokenViews} rugsTop={rugsTop as any} dir={state?.direction as any} onRotate={onRotate} onCellClick={onCellClick} backgroundUrl={"https://cdn.builder.io/api/v1/image/assets%2F9c98f74ce2d9433495c720297d8c0a5c%2Fdcd20b8d47da4d1883d4d20b82fcfab2?format=webp&width=800"} highlight={firstCell ? [{ x: firstCell.x, y: firstCell.y }] : undefined} tokenImageUrl="/algerian-avatar.svg" />
           </div>
-          <div className="rounded-xl border bg-white p-3 shadow-sm space-y-2">
-            <div className="text-sm font-semibold">Кубик: {state?.lastRoll ?? "—"}</div>
-            <Button onClick={onRoll} className="w-full">Бросить</Button>
+          <div className="rounded-xl border bg-white p-3 shadow-sm space-y-3">
+            <div className="flex items-center justify-between text-sm font-semibold">
+              <span>Кубик: {state?.lastRoll ?? "—"}</span>
+              <span className={gameFinished ? "text-muted-foreground" : isMyTurn ? "text-emerald-600" : "text-muted-foreground"}>{turnMessage}</span>
+            </div>
+            <Button onClick={onRoll} className="w-full" disabled={!canInteract || placingPhase !== 0}>Бросить</Button>
             <div className="text-xs text-muted-foreground">
               {placingPhase === 0 && "Сначала выберите направление и бросьте кубик"}
               {placingPhase === 1 && "Выберите первую клетку рядом с Ассамом"}
@@ -244,7 +247,7 @@ export default function SessionPage() {
         </div>
 
         <div className="rounded-xl border p-0 overflow-hidden">
-          <div className="border-b bg-muted/50 px-4 py-2 text-sm font-medium">Игроки</div>
+          <div className="border-b bg-muted/50 px-4 py-2 text-sm font-medium">И��роки</div>
           <ul className="divide-y">
             {players.map((p) => (
               <li key={p.id} className="flex items-center justify-between gap-3 px-4 py-2 text-sm">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Purpose

The user requested to implement turn-based gameplay where players take turns in sequence. Each player should see clear indicators of whose turn it is (their turn vs opponent's turn). The dice should have custom probabilities (1, 2, 2, 3, 3, 4) instead of standard 1-6. Additionally, the second player's carpet should be colored red.

## Code changes

- **Turn validation**: Added `ensureActiveTurn()` function to validate that only the active player can perform actions
- **Custom dice**: Modified `rollDice()` to use weighted dice faces `[1, 2, 2, 3, 3, 4]` instead of standard 1-6 random
- **Player colors**: Implemented custom color system where the second player gets red color (`#dc2626`)
- **UI improvements**: Added turn status indicators showing "Ваш ход" (Your turn) vs "Сейчас ход противника" (Opponent's turn)
- **Action restrictions**: Disabled game actions when it's not the player's turn or when game is finished
- **Player status display**: Enhanced player list to show individual turn status for each player
- **Code refactoring**: Replaced `.at(-1)` calls with `topStack()` helper function for better compatibility

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/eb31178662ae4cdab7d1fefafd115f2d/cosmos-hub)

👀 [Preview Link](https://eb31178662ae4cdab7d1fefafd115f2d-cosmos-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>eb31178662ae4cdab7d1fefafd115f2d</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->